### PR TITLE
added dependent destroy to food model

### DIFF
--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -1,6 +1,6 @@
 class Food < ApplicationRecord
   validates :name, :calories, presence: true
 
-  has_many :meal_foods
-  has_many :meals, through: :meal_foods
+  has_many :meal_foods, :dependent => :destroy
+  has_many :meals, through: :meal_foods, :dependent => :destroy
 end


### PR DESCRIPTION
Added dependent destroy so that when a food is deleted from the foods page, it also deletes in meals on diary.